### PR TITLE
fix error `provide_root_context` doesn't exist anymore

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -14,7 +14,7 @@ pub fn use_init_atom_root(cx: &ScopeState) -> &Rc<AtomRoot> {
 pub fn use_atom_root(cx: &ScopeState) -> &Rc<AtomRoot> {
     cx.use_hook(|_| match cx.consume_context::<AtomRoot>() {
         Some(root) => root,
-        None => cx.provide_root_context(AtomRoot::new(cx.schedule_update_any())),
+        None => cx.provide_context(AtomRoot::new(cx.schedule_update_any())),
     })
 }
 


### PR DESCRIPTION
Looks like this has been left. Correcting it.